### PR TITLE
expose openChannel to the pnp root instance(no build)

### DIFF
--- a/src/adapters/BaseAdapter.ts
+++ b/src/adapters/BaseAdapter.ts
@@ -32,6 +32,10 @@ export abstract class BaseAdapter<T extends AdapterSpecificConfig = AdapterSpeci
     this.state = newState;
   }
 
+  openChannel(): Promise<void> {
+    return Promise.resolve();
+  }
+
   getState(): Adapter.Status {
     return this.state;
   }

--- a/src/adapters/ic/NFIDAdapter.ts
+++ b/src/adapters/ic/NFIDAdapter.ts
@@ -129,6 +129,12 @@ export class NFIDAdapter extends BaseAdapter<NFIDAdapterConfig> implements Adapt
     }
   }
 
+  async openChannel(): Promise<void> {
+	if (this.signer) {
+		await this.signer.openChannel();
+	}
+  }
+
   async isConnected(): Promise<boolean> {
     return this.identity !== null && this.state === Adapter.Status.CONNECTED;
   }

--- a/src/adapters/ic/OisyAdapter.ts
+++ b/src/adapters/ic/OisyAdapter.ts
@@ -47,6 +47,12 @@ export class OisyAdapter extends BaseAdapter<OisyAdapterConfig> implements Adapt
       agent: this.agent,
     });
   }
+
+  async openChannel(): Promise<void> {
+	if (this.signer) {
+		await this.signer.openChannel();
+	}
+  }
   
   async isConnected(): Promise<boolean> {
     return this.agent !== null && this.signer !== null && this.signerAgent !== null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,10 @@ export class PNP implements PnpInterface {
     });
   }
 
+  async openChannel(): Promise<void> {
+      await this.connectionManager.openChannel();
+  }
+
   // Event emitter methods
   on<T>(event: PnpEventType, listener: PnpEventListener<T>): void {
     this.eventEmitter.on(event, listener);

--- a/src/managers/ConnectionManager.ts
+++ b/src/managers/ConnectionManager.ts
@@ -45,6 +45,12 @@ export class ConnectionManager implements PnpEventEmitter {
     });
   }
 
+  async openChannel(): Promise<void> {
+    if (this.provider) {
+      await this.provider.openChannel();
+    }
+  }
+
   async connect(walletId?: string): Promise<WalletAccount | null> {
     if (this.status === AdapterStatus.CONNECTING) {
       // If already connecting, wait for the current attempt to complete

--- a/src/types/AdapterTypes.ts
+++ b/src/types/AdapterTypes.ts
@@ -48,6 +48,7 @@ export interface AdapterAddresses {
 }
 
 export interface AdapterInterface {
+  openChannel(): Promise<void>;
   isConnected(): Promise<boolean>;
   connect(): Promise<any>;
   disconnect(): Promise<void>;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -111,6 +111,7 @@ export namespace Adapter {
 
   export interface Interface {
     // Core wallet functionality
+    openChannel(): Promise<void>;
     isConnected(): Promise<boolean>;
     connect(): Promise<Wallet.Account>;
     disconnect(): Promise<void>;


### PR DESCRIPTION
This should allow developers to call openChannel(which triggers popup) ahead of doing any ledger operation
some devices impose a requirement that popups can only be opened from on-click handler
if you need to do any async logic inside the onclick handler before actually issuing a ledger operation(say you must get a deposit subaccount from the backend) - you need to open channel ahead of time, right from onClick

This should resolve this by allowing devs to call `await PNP.openChannel()`